### PR TITLE
Rename 'worker set' to 'team' [RDM-16]

### DIFF
--- a/rotterdam/master.py
+++ b/rotterdam/master.py
@@ -13,7 +13,7 @@ from .proc import Proc
 from .arbiter import Arbiter
 from .injector import Injector
 from .consumer import Consumer
-from .worker_set import WorkerSet
+from .team import Team
 from .redis_extensions import extend_redis
 
 
@@ -38,9 +38,9 @@ class Master(Proc):
 
         self.config = config
 
-        self.injectors = WorkerSet(self, Injector)
-        self.arbiters = WorkerSet(self, Arbiter)
-        self.consumers = WorkerSet(self, Consumer)
+        self.injectors = Team(self, Injector)
+        self.arbiters = Team(self, Arbiter)
+        self.consumers = Team(self, Consumer)
 
         self.conn = None
         self.redis = None

--- a/rotterdam/master.py
+++ b/rotterdam/master.py
@@ -17,6 +17,11 @@ from .team import Team
 from .redis_extensions import extend_redis
 
 
+NUM_INJECTORS = 2
+
+NUM_ARBITERS = 1
+
+
 class Master(Proc):
 
     signal_map = {
@@ -114,9 +119,9 @@ class Master(Proc):
 
     def run(self):
         super(Master, self).run()
-        self.injectors.count = 2
-        self.arbiters.count = 1
-        self.consumers.count = self.config.num_consumers
+        self.injectors.set_size(NUM_INJECTORS)
+        self.arbiters.set_size(NUM_ARBITERS)
+        self.consumers.set_size(self.config.num_consumers)
 
         while True:
             try:
@@ -131,22 +136,22 @@ class Master(Proc):
                 sys.exit(-1)
 
     def expand_consumers(self, expansion_signal, *_):
-        new_count = self.consumers.count + 1
-        self.logger.info("Expanding number of consumers to %d", new_count)
-        self.consumers.count = new_count
+        new_size = self.consumers.size + 1
+        self.logger.info("Expanding number of consumers to %d", new_size)
+        self.consumers.set_size(new_size)
         self.arbiters.broadcast(expansion_signal)
 
     def contract_consumers(self, contraction_signal, *_):
-        if self.consumers.count <= 1:
+        if self.consumers.size <= 1:
             self.logger.info(
                 "Ignoring contraction, number of consumers already at %d",
-                self.consumers.count
+                self.consumers.size
             )
             return
 
-        new_count = self.consumers.count - 1
-        self.logger.info("Contracting number of consumers to %d", new_count)
-        self.consumers.count = new_count
+        new_size = self.consumers.size - 1
+        self.logger.info("Contracting number of consumers to %d", new_size)
+        self.consumers.size = new_size
         self.arbiters.broadcast(contraction_signal)
 
     def reload_config(self, *_):
@@ -159,9 +164,9 @@ class Master(Proc):
             self.conn.close()
             self.setup_connection()
 
-        self.injectors.count = 2
-        self.arbiters.count = 1
-        self.consumers.count = self.config.num_consumers
+        self.injectors.set_size(NUM_INJECTORS)
+        self.arbiters.set_size(NUM_ARBITERS)
+        self.consumers.set_size(self.config.num_consumers)
 
     def relaunch(self, *_):
         os.rename(
@@ -204,9 +209,9 @@ class Master(Proc):
 
         self.regroup(regenerate=False)
         if (
-                self.injectors.count == 0 and
-                self.arbiters.count == 0 and
-                self.consumers.count == 0
+                self.injectors.size == 0 and
+                self.arbiters.size == 0 and
+                self.consumers.size == 0
         ):
             try:
                 os.unlink(self.pid_file_path)

--- a/rotterdam/team.py
+++ b/rotterdam/team.py
@@ -12,11 +12,10 @@ class Team(object):
         self.workers = {}
 
     @property
-    def count(self):
+    def size(self):
         return len(self.workers)
 
-    @count.setter
-    def count(self, new_size):
+    def set_size(self, new_size):
         while len(self.workers) > new_size:
             self.remove_worker()
         while len(self.workers) < new_size:

--- a/rotterdam/team.py
+++ b/rotterdam/team.py
@@ -4,7 +4,7 @@ import signal
 import sys
 
 
-class WorkerSet(object):
+class Team(object):
 
     def __init__(self, master, worker_class):
         self.master = master


### PR DESCRIPTION
"worker set" is a bit awkward, "team" is a bit better.

Also removes the "count" property and it's heavy-lifting setter.
